### PR TITLE
Update infrastructure subcommittee page

### DIFF
--- a/content/about/information/infrastructure-committee.md
+++ b/content/about/information/infrastructure-committee.md
@@ -8,7 +8,7 @@ title: Forum Infrastructure Subcommittee
 
 ## Charter 
 
-Forum ballot [FORUM-010-](https://cabforum.org/2019/10/08/ballot-forum-10-re-charter-forum-infrastructure-working-group/) was reformed from the Forum Infrastructure Working Group (“FIWG”) to the Forum Infrastructure Subcommittee (FIS).
+Forum ballot [FORUM-010-](https://cabforum.org/2019/10/08/ballot-forum-10-re-charter-forum-infrastructure-working-group/) reformed from the Forum Infrastructure Working Group (“FIWG”) to the Forum Infrastructure Subcommittee (FIS).
 
 ### Scope 
 

--- a/content/about/information/infrastructure-committee.md
+++ b/content/about/information/infrastructure-committee.md
@@ -3,87 +3,44 @@ aliases:
 - /forum-infrastructure-wg/
 - /working-groups/forum-infrastructure-wg/
 date: 2018-10-06 22:48:57
-title: Forum Infrastructure Committee
+title: Forum Infrastructure Subcommittee
 ---
 
 ## Charter 
 
-Upon approval of the CAB Forum by ballot in accordance with section 5.3 of the Bylaws, the Forum Infrastructure Working Group (“FIWG”) is created to perform the activities as specified in this Charter, subject to the terms and conditions of the CA/Browser Forum Bylaws and Intellectual Property Rights (IPR) Policy, as such documents may change from time to time. The definitions found in the Forum’s Bylaws shall apply to capitalized terms in this Charter.
+Forum ballot [FORUM-010-](https://cabforum.org/2019/10/08/ballot-forum-10-re-charter-forum-infrastructure-working-group/) was reformed from the Forum Infrastructure Working Group (“FIWG”) to the Forum Infrastructure Subcommittee (FIS).
 
 ### Scope 
 
-The authorized scope of the Forum Infrastructure Working Group shall be as follows:
+The authorized scope of the Forum Infrastructure Subcommittee shall be as follows:
 
-1. To oversee the acquisition, operation, and maintenance of the common CA/Browser Forum website and wiki resources;
-1. To coordinate updates to public and Forum-facing web and wiki content in support of the Forum Webmaster role established in the Bylaws;
-1. To create and manage the division of access and content spaces required to help ensure the separation of the work of various Working Groups and accompanying IP commitments, as described in the Forum’s IPR Policy;
-1. To manage the Forum-level email lists and to offer management of working-group and subcommittee mailing lists as needed in support of the Forum List Manager role established in the Bylaws;
-1. To perform other activities ancillary to the primary activities listed above.
+- To oversee the acquisition, operation, and maintenance of the common CA/Browser Forum website and wiki resources;
+- To coordinate updates to public and Forum-facing web and wiki content in support of the Forum Webmaster role established in the Bylaws;
+- To create and manage the division of access and content spaces required to help ensure the separation of the work of various Working Groups and accompanying IP commitments, as described in the Forum’s IPR Policy;
+- To manage the technical means of production of guidelines and other documents produced by the Forum’s subcommittees;
+- To manage the Forum-level email lists and to offer management of working-group and subcommittee mailing lists as needed in support of the Forum List Manager role established in the Bylaws;
+- To perform other activities ancillary to the primary activities listed above.
 
-### Out of Scope 
+### End Date 
 
-The following items are considered out of scope for the Working Group under this charter:
+This Subcommittee shall continue until it is dissolved by a vote of the CA/B Forum.
 
-- The FIWG will not address coordination of Forum or Working Group face-to-face meetings.
-- The FIWG will not create Final Guidelines or Final Maintenance Guidelines as defined in the Bylaws and IPR Policy.
-- The FIWG shall provide recommendations of infrastructure acquisition or use to the Forum, but shall not impose requirements upon the rest of the Forum.
-- The FIWG will not address the acquisition or maintenance of software or services used for online meetings of the Forum Plenary or Working Groups.
+### Deliverables
 
-In addition to the above, the work of the FIWG in managing content updates to online content shall be offered to Working Groups and Subcommittees, but shall not supplant the responsibilities of Forum chairs or members to do so as required by the Bylaws.
+The Forum Infrastructure Subcommittee shall be responsible for delivering wiki and mailing list services to the Forum on an ongoing basis, and supplying access to these and to the management tools for these as is appropriate and required by the Forum. The subcommittee shall not propose any changes to the Bylaws or IPR agreements itself: where issues with these are identified, they may be redirected to the Forum as a whole or to appropriate subcommittees or working groups for further consideration.
 
-### Anticipated End Date 
+### Participation
 
-Given that the work of infrastructure support and management is expected to be consistent and ongoing, the FIWG is chartered without a specific end date. However, the FIWG may be dissolved at any time through a Forum ballot, as specified in the Bylaws, section 5.3.2c.
+Any member of the CAB Forum is eligible and may declare their participation in the Forum Infrastructure Subcommittee by requesting to be added to the mailing list.
 
-### Personnel and Participation 
+### Chair
 
-### Initial Chairs and Contacts 
+Jos Purvis shall be the initial Chair of the Forum Infrastructure Subcommittee. The Chair shall not have a fixed term, but the Subcommittee may change its Chair from time to time by consensus of the Members participating in the Subcommittee or by voting method chosen by the Members by consensus.
 
-The proposer of the ballot, Jos Purvis, will act as chair of the FIWG until the first Working Group Teleconference, at which time the group will select a chair and vice-chair either through election or acclamation of those present. The chair and vice-chair will serve two-year terms, the first of which will start upon their election and run through 31 October 2020.
+### Communication
 
-### Members Eligible to Participate 
+Subcommittee communications and documents shall be posted on mailing-lists where the mail-archives are publicly accessible, and the Subcommittee shall publish minutes of its meetings to the Forum wiki.
 
-The FIWG welcomes the participation of any Member organization of the Forum Plenary interested in this work, and also invites Interested Parties and Associate Members as defined in the Bylaws to participate in its meetings and work. In addition to organizations choosing to participate in the FIWG, the following people shall be automatically declared as Members of the FIWG:
+### Effect of Forum Bylaws Amendment for Subcommittees
 
-- The Forum Plenary Chair;
-- The Forum Plenary Vice-Chair;
-- The Forum Plenary Webmaster;
-- The Forum Plenary List Manager;
-- The Forum Plenary Questions List Coordinator.
-
-The Chair of each Forum Working Group shall be automatically declared a Member of the FIWG unless they specifically designate an alternate in their place. Participation in the FIWG does not alone qualify a participant for Forum membership.
-
-### Membership Declaration 
-
-Member organizations of the Forum that choose to participate in the FIWG may declare their participation and must do so prior to participating, in accordance with the IPR agreements of the Forum. The Chair of the FIWG shall establish a list for declarations of participation and manage it in accordance with the Bylaws and the IPR requirements documents.
-
-The following Forum Members have declared their participation in this Committee:
-
-| **Company**   | **Representative(s)**                  |
-| ------------- | -------------------------------------- |
-| Cisco Systems | Jos Purvis                             |
-| DigiCert      | Tim Hollebeek, Dean Coclin             |
-| Google        | Ryan Sleevi                            |
-| Mozilla       | Ben Wilson                             |
-| HARICA        | Dimitris Zacharopoulos                 |
-| GoDaddy       | Jim Gorz, Llewellyn Curran, Dre Armeda |
-
-### Voting and Voting Structure 
-
-Voting in the FIWG shall be limited to FIWG members who are listed as a voting Member of any other Working Group in the Forum. Voting shall be egalitarian: all Members shall vote together as a single class, with one vote granted to each Member organization. Ballots shall be adopted by the FIWG if the number of votes cast meets Quorum, and the number of votes in favor exceeds 50% of the votes cast. Quorum is defined as the larger of 3 or the average number of Member organizations that have participated in the last three FIWG Meetings or Teleconferences (not counting subcommittee meetings thereof). For transition purposes, if three meetings have not yet occurred, quorum is three (3). For the purposes of counting votes, automatically included members such as the Forum Webmaster may not cast votes separate from their Member organization.
-
-### Summary of Major WG Deliverables and Guidelines 
-
-The deliverables of the FIWG are defined in the Scope section above. In addition to the general focus of the Working Group, however, the following specific deliverables are defined:
-
-- A review of the current web, document review, and wiki software in use to help ensure it meets the security and content needs of the Forum;
-- Creation of separate wiki space for each Forum Working Group, to enable the division of content required by the IPR Policy;
-- A review of the current public web content and reorganization as required to support the new Forum Working Group changes.
-
-### Primary Means of Communication 
-
-The FIWG will communicate primarily through listserv-based email, and shall conduct periodic calls or face-to-face meetings as needed.
-
-### IPR Policy 
-
-As with all Forum Working Group activity, the CA/Browser Forum Intellectual Rights Policy v1.3 or later shall apply to all activities and work of the FIWG.
+In the event the Forum Bylaws are amended to add or modify general rules governing Forum Subcommittees and how they operate (“General Rules”), the provisions of the General Rules shall take precedence over this charter.


### PR DESCRIPTION
This update revises the infrastructure subcommittee page by replacing the old WG charter contents, with those found in the FORUM-010 ballot