### PR TITLE
Add section anchor for automatic external linking

### DIFF
--- a/pandoc/filters/headers.lua
+++ b/pandoc/filters/headers.lua
@@ -13,6 +13,7 @@ function Header(header)
         table.insert(header.content, link)
     end
 
+    local stringifiedHeader = pandoc.utils.stringify(header)
     local match = stringifiedHeader:match("^[%d%.]+")
     if match then
         local section = string.gsub(match, "%.$", "")

--- a/pandoc/filters/headers.lua
+++ b/pandoc/filters/headers.lua
@@ -17,7 +17,7 @@ function Header(header)
     local match = stringifiedHeader:match("^[%d%.]+")
     if match then
         local section = string.gsub(match, "%.$", "")
-        local section_id = pandoc.RawInline('html', '<span id="' .. header.identifier .. '" />')
+        local section_id = pandoc.RawInline('html', '<span id="' .. section .. '" />')
         table.insert(header.content, section_id)
     end
 

--- a/pandoc/filters/headers.lua
+++ b/pandoc/filters/headers.lua
@@ -17,7 +17,7 @@ function Header(header)
     local match = stringifiedHeader:match("^[%d%.]+")
     if match then
         local section = string.gsub(match, "%.$", "")
-        local section_id = pandoc.RawInline('html', '<span id="' .. section .. '" />')
+        local section_id = pandoc.RawInline('html', '<span id="section-' .. section .. '" />')
         table.insert(header.content, section_id)
     end
 

--- a/pandoc/filters/headers.lua
+++ b/pandoc/filters/headers.lua
@@ -13,5 +13,12 @@ function Header(header)
         table.insert(header.content, link)
     end
 
+    local match = stringifiedHeader:match("^[%d%.]+")
+    if match then
+        local section = string.gsub(match, "%.$", "")
+        local section_id = pandoc.RawInline('html', '<span id="' .. header.identifier .. '" />')
+        table.insert(header.content, section_id)
+    end
+
     return header
 end


### PR DESCRIPTION
Enable external links via for easy (automated) linking in external reference text using the following anchor in addition to the default anchor (similar to IETF):

https://cabforum.org/working-groups/smime/requirements/#1.1

in addition to:

https://cabforum.org/working-groups/smime/requirements/#11-overview