### PR TITLE
Fix NetSec anf Forum ballot feeds and RSS compliance

### DIFF
--- a/content/proceedings/ballots.md
+++ b/content/proceedings/ballots.md
@@ -8,8 +8,8 @@ forum_group_name: Forum
 layout: ballots
 outputs:
 - html
-- json
-- rss
+- ballots-json
+- ballots-rss
 ---
 
 Beginning with the adoption of the Extended Validation Guidelines in June 2007, the CA/Browser has tracked proposed ballots using a numbering system, and CA/Browser Forum member votes have become publicly available for votes occurring after February 2013. A tally of quorum and voting results is available here:  [https://docs.google.com/spreadsheet/ccc?key=0AjuWQ0oWc2scdDV5QWd5OGk1VWFfZW5XbWdDX1JqN2c#gid=4](https://docs.google.com/spreadsheet/ccc?key=0AjuWQ0oWc2scdDV5QWd5OGk1VWFfZW5XbWdDX1JqN2c#gid=4 "CAB Forum Voting Record")

--- a/content/working-groups/netsec/ballots.md
+++ b/content/working-groups/netsec/ballots.md
@@ -10,8 +10,8 @@ forum_group_name: Network Security Working Group
 layout: ballots
 outputs:
 - html
-- json
-- rss
+- ballots-json
+- ballots-rss
 ---
 
 ## Ballots by Status

--- a/layouts/_default/ballots.xml
+++ b/layouts/_default/ballots.xml
@@ -12,7 +12,7 @@
       <title>{{ .name }}</title>
       <link>{{ $.Permalink }}#{{ .name | anchorize }}</link>
       <guid>{{ $.Permalink }}#{{ .name | anchorize }}</guid>
-      <pubDate>{{ (time.AsTime .created_at) | time.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+      <pubDate>{{ (time.AsTime .created_at) | time.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <description>{{ .status }} in the {{ .forum_group_name }}</description>
     </item>
     {{- end -}}

--- a/layouts/_default/ballots.xml
+++ b/layouts/_default/ballots.xml
@@ -5,12 +5,14 @@
     <link>{{ .Permalink }}</link>
     <description>{{ .Description }}</description>
     <language>en-us</language>
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- with partial "ballots.html" . -}}
     {{- range . -}}
     <item>
       <title>{{ .name }}</title>
       <link>{{ $.Permalink }}#{{ .name | anchorize }}</link>
-      <pubDate>{{ .created_at | time.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+      <guid>{{ $.Permalink }}#{{ .name | anchorize }}</guid>
+      <pubDate>{{ (time.AsTime .created_at) | time.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
       <description>{{ .status }} in the {{ .forum_group_name }}</description>
     </item>
     {{- end -}}

--- a/layouts/shortcodes/ballots.html
+++ b/layouts/shortcodes/ballots.html
@@ -4,7 +4,7 @@
 {{- with partial "ballots.html" (dict "forum_group_name" $forum_group_name "status" $status) -}}
 <ul>
     {{- range . -}}
-    <li id="{{ .name | anchorize }}" title='Created at {{ .created_at | time.Format ":date_full" }} in the {{ .forum_group_name }}; current status "{{ .status }}"'>{{ .name }}</li>
+    <li id="{{ .name | anchorize }}" title='Created at {{ (time.AsTime .created_at) | time.Format ":date_full" }} in the {{ .forum_group_name }}; current status "{{ .status }}"'>{{ .name }}</li>
     {{- end -}}
 </ul>
 {{- else -}}


### PR DESCRIPTION
Fix output formats:

* [`content/proceedings/ballots.md`](diffhunk://#diff-43267d165e554ba026adbc9010c3edce7dfea6e6ed1757fa8df31aee9d556209L11-R12): Updated output formats from `json` and `rss` to `ballots-json` and `ballots-rss`.
* [`content/working-groups/netsec/ballots.md`](diffhunk://#diff-ca4ee8270e3497d458f849be5508943ca5abaf967264df3fb892fd95f5c6d187L13-R14): Updated output formats from `json` and `rss` to `ballots-json` and `ballots-rss`.
