### PR TITLE
Change Review Period to IPR Review Period

### DIFF
--- a/content/ballots.md
+++ b/content/ballots.md
@@ -16,9 +16,9 @@ outputs:
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 

--- a/content/proceedings/ballots.md
+++ b/content/proceedings/ballots.md
@@ -20,9 +20,9 @@ Beginning with the adoption of the Extended Validation Guidelines in June 2007, 
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 

--- a/content/working-groups/code-signing/ballots.md
+++ b/content/working-groups/code-signing/ballots.md
@@ -20,9 +20,9 @@ outputs:
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 

--- a/content/working-groups/netsec/ballots.md
+++ b/content/working-groups/netsec/ballots.md
@@ -20,9 +20,9 @@ outputs:
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 

--- a/content/working-groups/server/ballots.md
+++ b/content/working-groups/server/ballots.md
@@ -22,9 +22,9 @@ outputs:
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 

--- a/content/working-groups/smime/ballots.md
+++ b/content/working-groups/smime/ballots.md
@@ -20,9 +20,9 @@ outputs:
 
 {{< ballots status="Voting Period">}}
 
-### Review Period
+### IPR Review Period
 
-{{< ballots status="Review Period">}}
+{{< ballots status="IPR Review Period">}}
 
 ### Discussion Period
 


### PR DESCRIPTION
This pull request aligns with the merge of `IPR Review`, `Ballot Passed - Pending IPR Review` and `Review Period` statuses in the member tools to ensure that all ballots are included.

Standardization of terminology:

* [`content/ballots.md`](diffhunk://#diff-377bdc5316e57b69626fac86c8149b44a40fa5320f9e973a28881c0ec7e45eb3L19-R21): Changed "Review Period" to "IPR Review Period".
* [`content/proceedings/ballots.md`](diffhunk://#diff-43267d165e554ba026adbc9010c3edce7dfea6e6ed1757fa8df31aee9d556209L23-R25): Changed "Review Period" to "IPR Review Period".
* [`content/working-groups/code-signing/ballots.md`](diffhunk://#diff-6132a218a04ebf16aad1e98dab362b9ed3b8dc2edbb199773daf8747e5603e6fL23-R25): Changed "Review Period" to "IPR Review Period".
* [`content/working-groups/netsec/ballots.md`](diffhunk://#diff-ca4ee8270e3497d458f849be5508943ca5abaf967264df3fb892fd95f5c6d187L23-R25): Changed "Review Period" to "IPR Review Period".
* [`content/working-groups/server/ballots.md`](diffhunk://#diff-e02f4ca92dce97c36b9406d3a5a2a9e4ba696f308da61b2a7af9cfbdb18afb97L25-R27): Changed "Review Period" to "IPR Review Period".
* [`content/working-groups/smime/ballots.md`](diffhunk://#diff-01dfbebb4956d3566ad1cf1d3c8e2ca7faf51741efd33dcec3f090fc7ae7400eL23-R25): Changed "Review Period" to "IPR Review Period".