### PR TITLE
Plainify text for OpenGraph image

### DIFF
--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -5,9 +5,9 @@
 
     {{- $summary := " " -}}
     {{- if .Description -}}
-        {{- $summary = .Description -}}
+        {{- $summary = (.Description | plainify) -}}
     {{- else if .Summary -}}
-        {{- $summary = .Summary -}}
+        {{- $summary = (.Summary | plainify) -}}
     {{- else if eq .Data.Singular "author" -}}
         {{- $summary = (printf "View all articles authored by %s" .Data.Term ) -}}
     {{- else if eq .Data.Singular "tag" -}}


### PR DESCRIPTION
This pull request includes a small change to the `layouts/partials/image.html` file. The change ensures that descriptions and summaries are plainified before being assigned to the `$summary` variable.

* [`layouts/partials/image.html`](diffhunk://#diff-6df0b4e56673418819f3d04c957716668d3fc541d64d10bb50b3ad8c30381599L8-R10): Added the `plainify` filter to `.Description` and `.Summary` to ensure plain text formatting.