### PR TITLE
Please update the URL of Actalis' SSL Check tool

### DIFF
--- a/content/resources/tools.md
+++ b/content/resources/tools.md
@@ -31,7 +31,7 @@ TestSSL – https://testssl.sh/
 
 Wormly – https://www.wormly.com/test_ssl
 
-Actalis – https://extwebra.actalis.com/portal/uapub/tools/sslchecker
+Actalis SSL Check – https://sslcheck.actalis.com/
 
 ## Browser / Client Testing
 


### PR DESCRIPTION
Revised URL for Actalis' SSL Checking tool (as shown at https://cabforum.org/resources/tools/).