### PR TITLE
Update duration of FIPR subcommittee

### DIFF
--- a/content/about/information/ipr-subcommittee.md
+++ b/content/about/information/ipr-subcommittee.md
@@ -39,4 +39,4 @@ The FIPR will communicate primarily through listserv-based email and shall condu
 
 **6. End Date**
 
-The FIPR will submit its Deliverables to the Forum prior to April 1, 2025, and upon such date the Subcommittee is deemed dissolved.
+The FIPR will submit its Deliverables to the Forum prior to December 1, 2025, and upon such date the Subcommittee is deemed dissolved.


### PR DESCRIPTION
Per Ballot FORUM-034 the Forum IPR Subcommittee's charter is extended to Dec. 1, 2025