### PR TITLE
Link filename in text

### DIFF
--- a/content/posts/2025/2025-06-03-NSWG-Ballot-NS-008/index.md
+++ b/content/posts/2025/2025-06-03-NSWG-Ballot-NS-008/index.md
@@ -16,7 +16,7 @@ Aliases:
 
 This Review Notice is sent pursuant to Section 4.1 of the CA/Browser Forum’s Intellectual Property Rights Policy (v1.3). This Review Period of 30 days is for one Final Maintenance Guidelines. The complete Draft Maintenance Guideline that is the subject of this Review Notice is:
 
-<CA-Browser-Forum-NCSSR-2.0.5-redline.pdf>
+[CA-Browser-Forum-NCSSR-2.0.5-redline.pdf](<CA-Browser-Forum-NCSSR-2.0.5-redline.pdf>)
 
 ### Summary of Review
 


### PR DESCRIPTION
This pull request includes a minor change to the `content/posts/2025/2025-06-03-NSWG-Ballot-NS-008/index.md` file. The change updates a plain text reference to a PDF file by converting it into a clickable link for better accessibility.